### PR TITLE
PYENV_VERSION=3.10.12 Deprecated

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -82,7 +82,7 @@ To setup frappe framework version 14 bench set `PYENV_VERSION` environment varia
 bench init --skip-redis-config-generation --frappe-branch version-14 frappe-bench
 # Or set environment versions explicitly
 nvm use v16
-PYENV_VERSION=3.10.12 bench init --skip-redis-config-generation --frappe-branch version-14 frappe-bench
+PYENV_VERSION=3.10.13 bench init --skip-redis-config-generation --frappe-branch version-14 frappe-bench
 # Switch directory
 cd frappe-bench
 ```


### PR DESCRIPTION
The PYENV_VERSION 3.10.12 is deprecated the new version 3.10.13 was launched. here the reference link

https://hub.docker.com/_/python

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
